### PR TITLE
Fixes IPython notebook title margin.

### DIFF
--- a/mplleaflet/templates/ipynb.html
+++ b/mplleaflet/templates/ipynb.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 {% block style %}
+    .leaflet-container .leaflet-tile {
+       margin: 0;
+    }
     #map{{ mapid }} {
       height:{{ height }}px;
     }


### PR DESCRIPTION
This PR remove margins from leaflet-tiles in the IPython notebook template to fix an offset in the first tile.  The solution is thanks to @lennart0901 who fixed that for [folium](https://github.com/python-visualization/folium/pull/65).

Before,
![before](https://cloud.githubusercontent.com/assets/950575/5607391/bf7ed584-9438-11e4-9e61-f94f43dfe604.png)

and another after the fix
![after](https://cloud.githubusercontent.com/assets/950575/5607392/c2a6fb9c-9438-11e4-8c69-21b4eef9a5e2.png)