### PR TITLE
hack to avoid cross-origin pb in notebooks

### DIFF
--- a/mplleaflet/links.py
+++ b/mplleaflet/links.py
@@ -1,0 +1,51 @@
+from six import Module_six_moves_urllib as urllib
+
+class Link(object):
+    def __init__(self, url, download=False):
+        """Create a link object base on an url.
+        Parameters
+        ----------
+            url : str
+                The url to be linked
+            download : bool, default False
+                Whether the target document shall be loaded right now.
+        """
+        self.url = url
+        self.code = None
+        if download:
+            self.code = urllib.request.urlopen(self.url).read()
+
+class JavascriptLink(Link):
+    def render(self, embedded=False):
+        """Renders the object.
+        
+        Parameters
+        ----------
+            embedded : bool, default False
+                Whether the code shall be embedded explicitely in the render.
+        """
+        if embedded:
+            if self.code is None:
+                self.code = urllib.request.urlopen(self.url).read()
+            return '<script>{}</script>'.format(self.code)
+        else:
+            return '<script src="{}"></script>'.format(self.url)
+
+class CssLink(Link):
+    def render(self, embedded=False):
+        """Renders the object.
+        
+        Parameters
+        ----------
+            embedded : bool, default False
+                Whether the code shall be embedded explicitely in the render.
+        """
+        if embedded:
+            if self.code is None:
+                self.code = urllib.request.urlopen(self.url).read()
+            return '<style>{}</style>'.format(self.code)
+        else:
+            return '<link rel="stylesheet" href="{}" />'.format(self.url)
+            
+
+            

--- a/mplleaflet/templates/base.html
+++ b/mplleaflet/templates/base.html
@@ -1,6 +1,7 @@
 <head>
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.css" />
-  <script src="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.js"></script>
+  {% for link in links %}
+    {{link.render(embedded=embed_links)}}
+  {% endfor %}
   <style>
     {% block style %}
     #map{{ mapid }} {


### PR DESCRIPTION
#### Issue
I often work with a distant IPython notebook / jupyter server ; in that case, there are cross-origin issues in the browser, as `leaflet.css` and `leaflet.js` cannot be loaded.

#### Fix
I fix it in using `urllib2` and asking python to download and serve these files. There may be cleaner ways to do that ; especially in adapting the template.

#### Bonus
And I take the occasion to put the rendered figure in an iframe, so that it's javascript does not interact with the notebook's. This also enables to create an iframe with the same size as the original matplotlib figure.