### PR TITLE
Support custom jinja2 templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Github's Python ignore file
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/mplleaflet/.gitignore
+++ b/mplleaflet/.gitignore
@@ -1,0 +1,2 @@
+# ignore the rsynced directory
+mplexporter

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -19,8 +19,8 @@ _leaflet_js = JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7
 _leaflet_css = CssLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css')
 _attribution = '<a href="https://github.com/jwass/mplleaflet">mplleaflet</a>'
 
-def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
-                epsg=None, embed_links=False, jinja2_env=None, template_params=None):
+def fig_to_html(fig=None, template=None, tiles=None, crs=None,
+                epsg=None, embed_links=False, template_params=None):
     """
     Convert a Matplotlib Figure to a Leaflet map
 
@@ -28,8 +28,8 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
     ----------
     fig : figure, default gcf()
         Figure used to convert to map
-    template : string, default 'base.html'
-        The Jinja2 template to use
+    template : a Jinja2 Template, default None
+        The Jinja2 template to use, if none is given use the default 'base.html'
     tiles : string or tuple
         The tiles argument is used to control the map tile source in the
         Leaflet map. Several simple shortcuts exist: 'osm', 'mapquest open',
@@ -51,9 +51,6 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
         'crs' parameter.
     embed_links : bool, default False
         Whether external links (except tiles) shall be explicitely embedded in the final html.
-    jinja2_env : jinja2.Environment, default to the packages templates directory
-        A custom jinja2 Environment instance, allow the user to specify a custom
-        template directory.
     template_params : dict, default None,
         Extra parameters passed to the template
 
@@ -73,10 +70,10 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
         else:
             tiles = maptiles.tiles[tiles]
 
-    if jinja2_env is None:
+    if template is None:
         jinja2_env = Environment(loader=PackageLoader('mplleaflet', 'templates'),
                                  trim_blocks=True, lstrip_blocks=True)
-    template = jinja2_env.get_template(template)
+        template = jinja2_env.get_template(template)
 
     if fig is None:
         fig = plt.gcf()

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -19,11 +19,8 @@ _leaflet_js = JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7
 _leaflet_css = CssLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css')
 _attribution = '<a href="https://github.com/jwass/mplleaflet">mplleaflet</a>'
 
-env = Environment(loader=PackageLoader('mplleaflet', 'templates'),
-                  trim_blocks=True, lstrip_blocks=True)
-
 def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
-                epsg=None, embed_links=False):
+                epsg=None, embed_links=False, jinja2_env=None, template_params=None):
     """
     Convert a Matplotlib Figure to a Leaflet map
 
@@ -54,6 +51,11 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
         'crs' parameter.
     embed_links : bool, default False
         Whether external links (except tiles) shall be explicitely embedded in the final html.
+    jinja2_env : jinja2.Environment, default to the packages templates directory
+        A custom jinja2 Environment instance, allow the user to specify a custom
+        template directory.
+    template_params : dict, default None,
+        Extra parameters passed to the template
 
     Note: only one of 'crs' or 'epsg' may be specified. Both may be None, in
     which case the plot is assumed to be longitude / latitude.
@@ -71,7 +73,10 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
         else:
             tiles = maptiles.tiles[tiles]
 
-    template = env.get_template(template)
+    if jinja2_env is None:
+        jinja2_env = Environment(loader=PackageLoader('mplleaflet', 'templates'),
+                                 trim_blocks=True, lstrip_blocks=True)
+    template = jinja2_env.get_template(template)
 
     if fig is None:
         fig = plt.gcf()
@@ -96,6 +101,7 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
         'links': [_leaflet_js,_leaflet_css],
         'embed_links': embed_links,
     }
+    params.update(template_params if template_params else params)
     html = template.render(params)
 
     return html

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -98,7 +98,9 @@ def fig_to_html(fig=None, template=None, tiles=None, crs=None,
         'links': [_leaflet_js,_leaflet_css],
         'embed_links': embed_links,
     }
-    params.update(template_params if template_params else params)
+    if template_params:
+        params.update(template_params)
+
     html = template.render(params)
 
     return html


### PR DESCRIPTION
- Add support for custom jinja2 templates
- Ignore the rsynced mplexporter and ignore python auto-generated files (github provided gitignore) 
