### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include *.md
+
+include mplleaflet/templates/*.html
+recursive-include mplleaflet *.py
+recursive-include mplexporter *.py


### PR DESCRIPTION
The current source dist at PyPI is broken:

```
python setup.py install --single-version-externally-managed --record record.txt
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    with open('AUTHORS.md') as f:
IOError: [Errno 2] No such file or directory: 'AUTHORS.md'
```

I just added a `MANIFEST.in` and hopefully that will fix it.  (Since that is mostly the `AUTHORS.md` fault I felt responsible :wink:)