### PR TITLE
Read alpha as the `fillOpacity` property

### DIFF
--- a/mplleaflet/leaflet_renderer.py
+++ b/mplleaflet/leaflet_renderer.py
@@ -45,6 +45,7 @@ class LeafletRenderer(Renderer):
             'color': style['edgecolor'],
             'weight': style['edgewidth'],
             'opacity': style['alpha'],
+            'fillOpacity': style['alpha'],
         }
         if style['facecolor'] != 'none':
             leaflet_style['fillColor'] = style['facecolor']
@@ -66,9 +67,9 @@ class LeafletRenderer(Renderer):
         return svg_style
 
     def _svg_path(self, pathcodes, data):
-        """ 
+        """
         Return the SVG path's 'd' element.
-    
+
         """
         def gen_path_elements(pathcodes, data):
             counts = {'M': 1, 'L': 1, 'C': 3, 'Z': 0}


### PR DESCRIPTION
I am not sure if this is the best way to implement it because matplotlib's `alpha` is defined only once, while in leaflet we have `opacity` for the stroke opacity and `fillOpacity` for the patch opacity.

However, I believe we need to override leaflet's default `fillOpacity`, [which is only 0.2](http://leafletjs.com/reference.html#path-fillopacity), to fix visualizations like this one:

http://nbviewer.ipython.org/github/rsignell-usgs/mwra-wq/blob/master/notebooks/wq_test.ipynb