### PR TITLE
Add new parameter to fig_to_html function to manage the geojson float precision

### DIFF
--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -92,7 +92,7 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
 
     if float_precision:
         FloatEncoder._formatter = ".{}f".format(float_precision)
-        gjdata = json.dumps(renderer.geojson(), cls = FloatEncoder)
+        gjdata = json.dumps(renderer.geojson(), cls=FloatEncoder)
     else:
         gjdata = json.dumps(renderer.geojson())
     params = {

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -13,6 +13,7 @@ from jinja2 import Environment, PackageLoader
 
 from .leaflet_renderer import LeafletRenderer
 from .links import JavascriptLink, CssLink
+from .utils import FloatEncoder
 from . import maptiles
 
 # We download explicitly the CSS and the JS.
@@ -24,7 +25,7 @@ env = Environment(loader=PackageLoader('mplleaflet', 'templates'),
                   trim_blocks=True, lstrip_blocks=True)
 
 def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
-                epsg=None, embed_links=False):
+                epsg=None, embed_links=False, float_precision=None):
     """
     Convert a Matplotlib Figure to a Leaflet map
 
@@ -56,6 +57,8 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
     embed_links : bool, default False
         Whether external links (except tiles) shall be explicitly embedded in
         the final html.
+    float_precision : int, default None
+        The precision to be used for the floats in the embedded geojson.
 
     Note: only one of 'crs' or 'epsg' may be specified. Both may be None, in
     which case the plot is assumed to be longitude / latitude.
@@ -87,7 +90,11 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
 
     mapid = str(uuid.uuid4()).replace('-', '')
 
-    gjdata = json.dumps(renderer.geojson())
+    if float_precision:
+        FloatEncoder._formatter = ".{}f".format(float_precision)
+        gjdata = json.dumps(renderer.geojson(), cls = FloatEncoder)
+    else:
+        gjdata = json.dumps(renderer.geojson())
     params = {
         'geojson': gjdata,
         'width': fig.get_figwidth()*dpi,

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -25,7 +25,7 @@ env = Environment(loader=PackageLoader('mplleaflet', 'templates'),
                   trim_blocks=True, lstrip_blocks=True)
 
 def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
-                epsg=None, embed_links=False, float_precision=None):
+                epsg=None, embed_links=False, float_precision=6):
     """
     Convert a Matplotlib Figure to a Leaflet map
 
@@ -57,7 +57,7 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
     embed_links : bool, default False
         Whether external links (except tiles) shall be explicitly embedded in
         the final html.
-    float_precision : int, default None
+    float_precision : int, default 6
         The precision to be used for the floats in the embedded geojson.
 
     Note: only one of 'crs' or 'epsg' may be specified. Both may be None, in
@@ -90,11 +90,8 @@ def fig_to_html(fig=None, template='base.html', tiles=None, crs=None,
 
     mapid = str(uuid.uuid4()).replace('-', '')
 
-    if float_precision:
-        FloatEncoder._formatter = ".{}f".format(float_precision)
-        gjdata = json.dumps(renderer.geojson(), cls=FloatEncoder)
-    else:
-        gjdata = json.dumps(renderer.geojson())
+    FloatEncoder._formatter = ".{}f".format(float_precision)
+    gjdata = json.dumps(renderer.geojson(), cls=FloatEncoder)
     params = {
         'geojson': gjdata,
         'width': fig.get_figwidth()*dpi,

--- a/mplleaflet/utils.py
+++ b/mplleaflet/utils.py
@@ -1,3 +1,7 @@
+import json
+from json.encoder import JSONEncoder
+
+
 def iter_rings(data, pathcodes):
     ring = []
     # TODO: Do this smartly by finding when pathcodes changes value and do
@@ -15,3 +19,62 @@ def iter_rings(data, pathcodes):
 
     if len(ring):
         yield ring
+
+
+class FloatEncoder(JSONEncoder):
+    _formatter = ".3f"
+
+    def iterencode(self, o, _one_shot=False):
+        """Encode the given object and yield each string
+        representation as available.
+        For example::
+            for chunk in JSONEncoder().iterencode(bigobject):
+                mysocket.write(chunk)
+        """
+        c_make_encoder_original = json.encoder.c_make_encoder
+        json.encoder.c_make_encoder = None
+
+        if self.check_circular:
+            markers = {}
+        else:
+            markers = None
+        if self.ensure_ascii:
+            _encoder = json.encoder.encode_basestring_ascii
+        else:
+            _encoder = json.encoder.encode_basestring
+
+        def floatstr(o, allow_nan=self.allow_nan,
+                     _repr=lambda x: format(x, self._formatter),
+                     _inf=float("inf"), _neginf=-float("inf")):
+            # Check for specials.  Note that this type of test is processor
+            # and/or platform-specific, so do tests which don't depend on the
+            # internals.
+            if o != o:
+                text = 'NaN'
+            elif o == _inf:
+                text = 'Infinity'
+            elif o == _neginf:
+                text = '-Infinity'
+            else:
+                return _repr(o)
+
+            if not allow_nan:
+                raise ValueError(
+                    "Out of range float values are not JSON compliant: " +
+                    repr(o))
+
+            return text
+
+        if (_one_shot and json.encoder.c_make_encoder is not None
+                and self.indent is None):
+            _iterencode = json.encoder.c_make_encoder(
+                markers, self.default, _encoder, self.indent,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, self.allow_nan)
+        else:
+            _iterencode = json.encoder._make_iterencode(
+                markers, self.default, _encoder, self.indent, floatstr,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, _one_shot)
+        json.encoder.c_make_encoder = c_make_encoder_original
+        return _iterencode(o, 0)


### PR DESCRIPTION
**Motivation**: the `fig_to_html` function embeds a geojson that can be very heavy when there are a lot of coordinates and features.
According to [this](https://tools.ietf.org/html/rfc7946#section-11.2) most of the time extra float precision on the coordinates doesn't have a visible effect.

With the PR you can add `float_precision` to the `fig_to_html` function and when the geojson is created the floats will be formatted.

**Example**:

```python
import mplleaflet
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
ax.plot((1,2.365485622,36.254685), (1,2,3.3))
```
If we save the `fig` to html in the usual way we get:
```python
mplleaflet.fig_to_html(fig)
```
We get
```html
...
var gjData = {
    "type": "FeatureCollection", 
    "features": [{
        "type": "Feature", 
        "geometry": {
            "type": "LineString", 
            "coordinates": [[1.0, 1.0], [2.365485622, 2.0], [36.254685, 3.3]]
        }, 
        "properties": {"color": "#1F77B4", "weight": 1.5, "opacity": 1, "fillOpacity": 1}
    }]
};
...
```
If we use the new keyword:
```python
mplleaflet.fig_to_html(fig, float_precision=3)
```
We would get:
```html
...
var gjData = {
    "type": "FeatureCollection", 
    "features": [{
        "type": "Feature", 
        "geometry": {
            "type": "LineString", 
            "coordinates": [[1.000, 1.000], [2.365, 2.000], [36.255, 3.300]]
        }, 
        "properties": {"color": "#1F77B4", "weight": 1.500, "opacity": 1, "fillOpacity": 1}
    }]
};
...
```
The example above is not very representative but if you are using contours, for instance, the difference is very important.