### PR TITLE
Fixes the "Consider using IPython.display.IFrame" warning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mplexporter"]
 	path = mplexporter
-	url = git@github.com:jwass/mplexporter.git
+	url = http://github.com/jwass/mplexporter.git

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -158,7 +158,8 @@ def display(fig=None, closefig=True, **kwargs):
     html = fig_to_html(fig, **kwargs)
 
     # We embed everything in an iframe.
-    return IPython.display.IFrame(src="data:text/html;base64,{html}".format(html = base64.b64encode(html.encode('utf8')).decode('utf8')), width='100%', height=int(60.*fig.get_figheight()))
+    src = "data:text/html;base64,{html}".format(html = base64.b64encode(html.encode('utf8')).decode('utf8'))
+    return IFrame(src=src, width='100%', height=int(60.*fig.get_figheight()))
 
 
 def show(fig=None, path='_map.html', **kwargs):

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -15,6 +15,7 @@ from .leaflet_renderer import LeafletRenderer
 from .links import JavascriptLink, CssLink
 from .utils import FloatEncoder
 from . import maptiles
+from IPython.display import IFrame
 
 # We download explicitly the CSS and the JS.
 _leaflet_js = JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js')
@@ -157,12 +158,8 @@ def display(fig=None, closefig=True, **kwargs):
     html = fig_to_html(fig, **kwargs)
 
     # We embed everything in an iframe.
-    iframe_html = '<iframe src="data:text/html;base64,{html}" width="{width}" height="{height}"></iframe>'\
-    .format(html = base64.b64encode(html.encode('utf8')).decode('utf8'),
-            width = '100%',
-            height= int(60.*fig.get_figheight()),
-           )
-    return HTML(iframe_html)
+    return IPython.display.IFrame(src="data:text/html;base64,{html}".format(html = base64.b64encode(html.encode('utf8')).decode('utf8')), width='100%', height=int(60.*fig.get_figheight()))
+
 
 def show(fig=None, path='_map.html', **kwargs):
     """

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -8,7 +8,7 @@ import base64
 import six
 
 import matplotlib.pyplot as plt
-from mplexporter.mplexporter.exporter import Exporter
+from .mplexporter.exporter import Exporter
 from jinja2 import Environment, PackageLoader
 
 from .leaflet_renderer import LeafletRenderer

--- a/mplleaflet/_display.py
+++ b/mplleaflet/_display.py
@@ -8,7 +8,7 @@ import base64
 import six
 
 import matplotlib.pyplot as plt
-from .mplexporter.exporter import Exporter
+from mplexporter.mplexporter.exporter import Exporter
 from jinja2 import Environment, PackageLoader
 
 from .leaflet_renderer import LeafletRenderer

--- a/mplleaflet/leaflet_renderer.py
+++ b/mplleaflet/leaflet_renderer.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from functools import partial
 
 from jinja2 import Template
-from .mplexporter.renderers.base import Renderer
+from mplexporter.mplexporter.renderers.base import Renderer
 import numpy as np
 
 from .utils import iter_rings

--- a/mplleaflet/leaflet_renderer.py
+++ b/mplleaflet/leaflet_renderer.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from functools import partial
 
 from jinja2 import Template
-from mplexporter.mplexporter.renderers.base import Renderer
+from .mplexporter.renderers.base import Renderer
 import numpy as np
 
 from .utils import iter_rings

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url=DOWNLOAD_URL,
     download_url=DOWNLOAD_URL,
     license=LICENSE,
-    packages=find_packages(),
+    packages=["mplleaflet","mplexporter"],
     package_data={'': ['*.html']}, # Include the templates
     install_requires=[
         "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
     install_requires=[
         "jinja2",
         "six",
+        "ipython",
     ],
 )


### PR DESCRIPTION
This commit removes the "Consider using IPython.display.IFrame" warning.
To fix this I had to changes the link in the .gitmodules so that cloning the repository does not give any error